### PR TITLE
Create build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build Godot Project
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  Godot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code 
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Build
+        id: build
+        uses: krynv/build-godot-action@v1.0.0
+        with:
+          name: PS2.Visual.Novel.Tool.exe
+          preset: Windows Desktop
+          debugMode: "true"
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PS2.Visual.Novel.Tool
+          path: ${{ github.workspace }}/${{ steps.build.outputs.build }}
+
+  Release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: Godot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download from Github
+        uses: actions/download-artifact@v4
+        with:
+          path: assets
+
+      - name: Re-zip artifacts
+        run: |
+          TAG_NAME=$(basename "$GITHUB_REF")
+          cd assets
+          for dir in */ ; do
+            zip -r "${dir%/}.$TAG_NAME.zip" "$dir"
+          done
+        shell: bash
+
+      - name: Release to Github
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            assets/*.zip


### PR DESCRIPTION
Add a github action script for ci auto build.
It will build an executable after any connit has been committed, tag has been pushed, or any PR has been generated, and add the generated executable file to the release page corresponding to the tag.
Known bugs (or just feature): `debugMode` must be "true", or the memory usage lable will always be zero.
Preview:
 tag and release https://github.com/Manicsteiner/PS2-Visual-Novel-Tool/actions/runs/12747588639
 commit https://github.com/Manicsteiner/PS2-Visual-Novel-Tool/actions/runs/12749309230